### PR TITLE
fix testcases

### DIFF
--- a/src/recovery/checkpoint_manager.hpp
+++ b/src/recovery/checkpoint_manager.hpp
@@ -110,7 +110,7 @@ class CPRManager {
               record.epoch = checkpoint_epoch_.load() + 1;
 
               table_ref_.ForEach(
-                  [&](std::string_view key, DataItem& data_item) {
+                  [&](std::string_view key, LineairDB::DataItem& data_item) {
                     data_item.ExclusiveLock();
 
                     Logger::LogRecord::KeyValuePair kvp;
@@ -118,14 +118,9 @@ class CPRManager {
                     if (data_item.checkpoint_buffer.IsEmpty()) {
                       // this data item holds version which has written before
                       // the point of consistency.
-                      std::memcpy(reinterpret_cast<void*>(&kvp.value),
-                                  data_item.value(), data_item.size());
-                      kvp.size = data_item.size();
+                      kvp.buffer = data_item.buffer.toString();
                     } else {
-                      std::memcpy(reinterpret_cast<void*>(&kvp.value),
-                                  data_item.checkpoint_buffer.value,
-                                  data_item.checkpoint_buffer.size);
-                      kvp.size = data_item.checkpoint_buffer.size;
+                      kvp.buffer = data_item.checkpoint_buffer.toString();
                       data_item.checkpoint_buffer.Reset(nullptr, 0);
                     }
                     kvp.tid.epoch = record.epoch;

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -59,18 +59,10 @@ void ThreadLocalLogger::Enqueue(const WriteSetType& ws_ref, EpochNumber epoch,
     record.epoch = epoch;
 
     for (auto& snapshot : ws_ref) {
-      /*
-      assert(snapshot.data_item_copy.buffer.size < 256 &&
-             "WANTFIX: LineairDB's log manager can hold only 256-bytes for a "
-             "buffer of a single write operation.");
-      */
       Logger::LogRecord::KeyValuePair kvp;
-      kvp.key = snapshot.key;
-      std::memcpy(reinterpret_cast<void*>(&kvp.value),
-                  snapshot.data_item_copy.buffer.value,
-                  snapshot.data_item_copy.buffer.size);
-      kvp.size = snapshot.data_item_copy.buffer.size;
-      kvp.tid  = snapshot.data_item_copy.transaction_id.load();
+      kvp.key    = snapshot.key;
+      kvp.buffer = snapshot.data_item_copy.buffer.toString();
+      kvp.tid    = snapshot.data_item_copy.transaction_id.load();
 
       record.key_value_pairs.emplace_back(std::move(kvp));
     }

--- a/src/recovery/logger.h
+++ b/src/recovery/logger.h
@@ -23,8 +23,8 @@
 #include <msgpack.hpp>
 
 #include "logger_base.h"
+#include "types/data_buffer.hpp"
 #include "types/definitions.h"
-#include "types/snapshot.hpp"
 
 namespace LineairDB {
 namespace Recovery {
@@ -55,11 +55,9 @@ class Logger {
   struct LogRecord {
     struct KeyValuePair {
       std::string key;
-      // WANTFIX: dynamically change array size
-      std::array<std::byte, 2048> value;
-      size_t size;
+      std::string buffer;
       TransactionId tid;
-      MSGPACK_DEFINE(key, value, size, tid);
+      MSGPACK_DEFINE(key, buffer, tid);
     };
 
     EpochNumber epoch;

--- a/src/types/data_buffer.hpp
+++ b/src/types/data_buffer.hpp
@@ -54,7 +54,14 @@ struct DataBuffer {
     std::memcpy(value, v, s);
   }
   void Reset(const DataBuffer& rhs) { Reset(rhs.value, rhs.size); }
+  void Reset(const std::string& rhs) {
+    Reset(reinterpret_cast<const std::byte*>(rhs.data()), rhs.size());
+  }
   bool IsEmpty() const { return size == 0; }
+
+  std::string toString() const {
+    return std::string(reinterpret_cast<char*>(value), size);
+  }
 };
 }  // namespace LineairDB
 #endif /* LINEAIRDB_DATA_BUFFER_HPP */

--- a/src/types/data_buffer.hpp
+++ b/src/types/data_buffer.hpp
@@ -22,33 +22,32 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
 #include "util/logger.hpp"
 
 namespace LineairDB {
 
 struct DataBuffer {
-
   inline static size_t DefaultBufferSize = 512;
 
   std::byte* value;
   size_t size;
 
-  // thread unsafe
+  // WARNING: thread unsafe
   static void SetDefaultBufferSize(size_t buf_size) {
     DefaultBufferSize = buf_size;
   }
 
-  DataBuffer() : size(0) {
-    value = new std::byte[DefaultBufferSize];
-  }
+  DataBuffer() : size(0) { value = new std::byte[DefaultBufferSize]; }
 
   void Reset(const std::byte* v, const size_t s) {
     if (DefaultBufferSize < s) {
       SPDLOG_ERROR("write buffer overflow. expected: {0}, capacity: {1}", s,
                    DefaultBufferSize);
-      // throw std::runtime_error("The size of the write value is greater than DefaultBufferSize");
-      // TODO: use realloc and prevent exception
+      std::cerr << "ERROR in DataBuffer: The size of the write value is "
+                   "greater than DefaultBufferSize";
+      // TODO: use realloc to prevent failure
       exit(EXIT_FAILURE);
     }
     size = s;

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -51,27 +51,37 @@ TEST_F(DatabaseTest, InstantiateWithConfig) {
   ASSERT_NO_THROW(db_ = std::make_unique<LineairDB::Database>(conf));
 }
 
-TEST_F(DatabaseTest, IsbufferSizeConfigurable) {
+TEST_F(DatabaseTest, DeathTest_IsbufferSizeConfigurable) {
   db_.reset(nullptr);
+
   LineairDB::Config conf;
-  conf.checkpoint_period = 1;
+  conf.checkpoint_period    = 1;
+  conf.max_thread           = 1;
   conf.enable_checkpointing = false;
+
   std::array<std::byte, 1024> alice;
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   {                                 // expect to fail
     conf.internal_buffer_size = 1;  // byte
-    ASSERT_NO_THROW(db_ = std::make_unique<LineairDB::Database>(conf));
-    EXPECT_DEATH({
-        TestHelper::writeBufferAsAlice<decltype(alice)>(db_.get(), alice);}
-        , "DEATH");
+    EXPECT_DEATH(
+        {
+          LineairDB::Database db(conf);
+          TestHelper::writeBufferAsAlice<decltype(alice)>(&db, alice);
+        },
+        ".*ERROR in DataBuffer.*");
   }
 
   {                                    // expect to succeess
     conf.internal_buffer_size = 1024;  // byte
-    db_.reset(nullptr);
-    ASSERT_NO_THROW(db_ = std::make_unique<LineairDB::Database>(conf));
-    EXPECT_NO_THROW(
-        TestHelper::writeBufferAsAlice<decltype(alice)>(db_.get(), alice));
+    EXPECT_EXIT(
+        {
+          LineairDB::Database db(conf);
+          TestHelper::writeBufferAsAlice<decltype(alice)>(&db, alice);
+          exit(EXIT_SUCCESS);
+        },
+        ::testing::ExitedWithCode(EXIT_SUCCESS), ".*");
   }
 }
 

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -51,17 +51,9 @@ void RetryTransactionUntilCommit(LineairDB::Database* db,
 
 template <typename T>
 void writeBufferAsAlice(LineairDB::Database* db, T desired) {
-  std::atomic<bool> transaction_terminated(false);
-  std::condition_variable cond;
-  std::mutex mtx;
-
   auto& tx = db->BeginTransaction();
-  tx.Write("alice", reinterpret_cast<std::byte*>(&desired),
-                 sizeof(desired));
-  db->EndTransaction(tx, [&](auto) {transaction_terminated.store(true);});
-
-  std::unique_lock<std::mutex> lk(mtx);
-  cond.wait(lk, [&] { return transaction_terminated.load(); });
+  tx.Write("alice", reinterpret_cast<std::byte*>(&desired), sizeof(desired));
+  db->EndTransaction(tx, [&](auto) {});
 }
 
 bool DoTransactions(LineairDB::Database* db,


### PR DESCRIPTION
This PR fixes testcases.

The following snippet is the output:

```c++
~/l/t/L/build►tests/database_test --gtest_filter="**Isbuffer*"
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DatabaseTest
[ RUN      ] DatabaseTest.DeathTest_IsbufferSizeConfigurable
[Thread 26947652] [2022-08-23 18:00:41.460] [info] [database_impl.h:53] LineairDB instance has been constructed. [+5msec]
[Thread 26947652] [2022-08-23 18:00:41.462] [info] [database_impl.h:225] Start recovery process [+1msec]
[Thread 26947652] [2022-08-23 18:00:41.465] [debug] [database_impl.h:229]   Durable epoch is resumed from 1 [+2msec]
[Thread 26947652] [2022-08-23 18:00:41.470] [debug] [logger.cpp:133] Replay the logs in epoch 0-0 [+5msec]
[Thread 26947652] [2022-08-23 18:00:41.470] [debug] [logger.cpp:134] Check WorkingDirectory ./lineairdb_logs [+0msec]
[Thread 26947652] [2022-08-23 18:00:41.472] [debug] [database_impl.h:251]   Global epoch is resumed from 1 [+1msec]
[Thread 26947652] [2022-08-23 18:00:41.472] [info] [database_impl.h:253] Finish recovery process [+0msec]
[Thread 26947652] [2022-08-23 18:00:42.506] [debug] [database_impl.h:76] Epoch number and Durable epoch number are ended at 11, and 1, respectively. [+1033msec]
[Thread 26947652] [2022-08-23 18:00:42.506] [info] [database_impl.h:77] LineairDB instance has been destructed. [+0msec]
Running main() from /Users/nikezono/lineairdb-mysql/third_party/LineairDB/third_party/googletest/googletest/src/gtest_main.cc
[Thread 26947693] [2022-08-23 18:00:42.687] [info] [database_impl.h:53] LineairDB instance has been constructed. [+0msec]
[Thread 26947693] [2022-08-23 18:00:42.688] [info] [database_impl.h:225] Start recovery process [+0msec]
[Thread 26947693] [2022-08-23 18:00:42.688] [debug] [database_impl.h:229]   Durable epoch is resumed from 1 [+0msec]
[Thread 26947693] [2022-08-23 18:00:42.693] [debug] [logger.cpp:133] Replay the logs in epoch 0-0 [+5msec]
[Thread 26947693] [2022-08-23 18:00:42.693] [debug] [logger.cpp:134] Check WorkingDirectory ./lineairdb_logs [+0msec]
[Thread 26947693] [2022-08-23 18:00:42.694] [debug] [database_impl.h:251]   Global epoch is resumed from 1 [+0msec]
[Thread 26947693] [2022-08-23 18:00:42.694] [info] [database_impl.h:253] Finish recovery process [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.735] [debug] [database_impl.h:76] Epoch number and Durable epoch number are ended at 11, and 1, respectively. [+1040msec]
[Thread 26947693] [2022-08-23 18:00:43.735] [info] [database_impl.h:77] LineairDB instance has been destructed. [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [info] [database_impl.h:53] LineairDB instance has been constructed. [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [info] [database_impl.h:225] Start recovery process [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [debug] [database_impl.h:229]   Durable epoch is resumed from 1 [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [debug] [logger.cpp:133] Replay the logs in epoch 0-1 [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [debug] [logger.cpp:134] Check WorkingDirectory ./lineairdb_logs [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [debug] [database_impl.h:251]   Global epoch is resumed from 1 [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.739] [info] [database_impl.h:253] Finish recovery process [+0msec]
[Thread 26947693] [2022-08-23 18:00:43.742] [error] [data_buffer.hpp:47] write buffer overflow. expected: 1024, capacity: 1 [+2msec]
Running main() from /Users/nikezono/lineairdb-mysql/third_party/LineairDB/third_party/googletest/googletest/src/gtest_main.cc
[Thread 26947884] [2022-08-23 18:00:43.861] [info] [database_impl.h:53] LineairDB instance has been constructed. [+0msec]
[Thread 26947884] [2022-08-23 18:00:43.862] [info] [database_impl.h:225] Start recovery process [+1msec]
[Thread 26947884] [2022-08-23 18:00:43.862] [debug] [database_impl.h:229]   Durable epoch is resumed from 1 [+0msec]
[Thread 26947884] [2022-08-23 18:00:43.864] [debug] [logger.cpp:133] Replay the logs in epoch 0-0 [+1msec]
[Thread 26947884] [2022-08-23 18:00:43.864] [debug] [logger.cpp:134] Check WorkingDirectory ./lineairdb_logs [+0msec]
[Thread 26947884] [2022-08-23 18:00:43.864] [debug] [database_impl.h:251]   Global epoch is resumed from 1 [+0msec]
[Thread 26947884] [2022-08-23 18:00:43.864] [info] [database_impl.h:253] Finish recovery process [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.895] [debug] [database_impl.h:76] Epoch number and Durable epoch number are ended at 11, and 1, respectively. [+1030msec]
[Thread 26947884] [2022-08-23 18:00:44.895] [info] [database_impl.h:77] LineairDB instance has been destructed. [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [info] [database_impl.h:53] LineairDB instance has been constructed. [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [info] [database_impl.h:225] Start recovery process [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [debug] [database_impl.h:229]   Durable epoch is resumed from 1 [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [debug] [logger.cpp:133] Replay the logs in epoch 0-1 [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [debug] [logger.cpp:134] Check WorkingDirectory ./lineairdb_logs [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [debug] [database_impl.h:251]   Global epoch is resumed from 1 [+0msec]
[Thread 26947884] [2022-08-23 18:00:44.922] [info] [database_impl.h:253] Finish recovery process [+0msec]
[       OK ] DatabaseTest.DeathTest_IsbufferSizeConfigurable (3501 ms)
[----------] 1 test from DatabaseTest (3501 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3502 ms total)
[  PASSED  ] 1 test.
```